### PR TITLE
ci: add multi-arch Docker builds (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -48,5 +54,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Adds QEMU and Buildx setup to build images for both linux/amd64 and linux/arm64
- Matches the supported_architectures declared in rtappstore config.json
- Without this, arm64 runtipi hosts would fail to pull the image

https://claude.ai/code/session_01FoMr4ESFCbXMGGvRCH9dCk