### PR TITLE
ci: make GHCR package public after each release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Make package public
+        run: |
+          curl -s -X PATCH \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/user/packages/container/fpv-inventory" \
+            -d '{"visibility":"public"}'


### PR DESCRIPTION
Adds a step after the Docker push that calls the GitHub API to set the package visibility to public.

This ensures the image is pullable by runtipi without authentication on every release, not just after a manual visibility change in the UI.

https://claude.ai/code/session_01FoMr4ESFCbXMGGvRCH9dCk