### PR TITLE
ci: remove ineffective Make package public step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Make package public
-        run: |
-          curl -s -X PATCH \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/user/packages/container/fpv-inventory" \
-            -d '{"visibility":"public"}'


### PR DESCRIPTION
Removes the curl step that tried to change package visibility via GITHUB_TOKEN — it always returned 404. The package is now public because the repo is public, and future publishes from a public repo will remain public automatically.

https://claude.ai/code/session_01FoMr4ESFCbXMGGvRCH9dCk