### PR TITLE
fix(tests): strengthen quick-add tests and fix NaN parent_id crash

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -414,9 +414,15 @@ export function makeHandler(db: DB) {
       const status = (form.get("status")?.toString() ?? "unused") as PartStatus;
       const notes = form.get("notes")?.toString().trim() || undefined;
       const parentIdStr = form.get("parent_id")?.toString();
-      const parent_id = parentIdStr ? parseInt(parentIdStr, 10) : null;
+      const parsedParentId = parentIdStr ? parseInt(parentIdStr, 10) : null;
+      const parent_id = (parsedParentId != null && !isNaN(parsedParentId)) ? parsedParentId : null;
 
-      createPart(db, { name, quantity, status, notes, parent_id });
+      try {
+        createPart(db, { name, quantity, status, notes, parent_id });
+      } catch (err) {
+        console.error("Failed to create part:", err);
+        return new Response("Failed to create part", { status: 500 });
+      }
 
       const redirect = parent_id != null ? `/parts/${parent_id}` : "/";
       return new Response(null, { status: 303, headers: { Location: redirect } });
@@ -442,7 +448,12 @@ export function makeHandler(db: DB) {
       const notes = form.get("notes")?.toString();
       const quantityStr = form.get("quantity")?.toString();
       const quantity = quantityStr != null ? parseInt(quantityStr, 10) : undefined;
-      updatePart(db, id, { status, notes, quantity });
+      try {
+        updatePart(db, id, { status, notes, quantity });
+      } catch (err) {
+        console.error("Failed to update part:", err);
+        return new Response("Failed to update part", { status: 500 });
+      }
       return new Response(null, { status: 303, headers: { Location: `/parts/${id}` } });
     }
 
@@ -456,7 +467,12 @@ export function makeHandler(db: DB) {
       const newParentIdStr = form.get("new_parent_id")?.toString();
       const newParentId = newParentIdStr ? parseInt(newParentIdStr, 10) : null;
       const notes = form.get("notes")?.toString() || undefined;
-      movePart(db, id, newParentId, notes);
+      try {
+        movePart(db, id, newParentId, notes);
+      } catch (err) {
+        console.error("Failed to move part:", err);
+        return new Response("Failed to move part", { status: 500 });
+      }
       const redirect = newParentId != null ? `/parts/${newParentId}` : "/";
       return new Response(null, { status: 303, headers: { Location: redirect } });
     }

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -28,7 +28,7 @@ Deno.test("GET / lists top-level parts", async () => {
 
 // ─── Quick-add (POST /parts) ──────────────────────────────────────────────────
 
-Deno.test("POST /parts creates a part and redirects", async () => {
+Deno.test("POST /parts creates a part and redirects to homepage", async () => {
   const { handler } = makeApp();
   const form = new FormData();
   form.append("name", "0702 Motor");
@@ -36,7 +36,20 @@ Deno.test("POST /parts creates a part and redirects", async () => {
   form.append("status", "unused");
   const res = await handler(new Request("http://localhost/parts", { method: "POST", body: form }));
   assertEquals(res.status, 303);
-  assertStringIncludes(res.headers.get("Location") ?? "", "/");
+  assertEquals(res.headers.get("Location"), "/");
+});
+
+Deno.test("POST /parts then GET / shows the new part", async () => {
+  const { handler } = makeApp();
+  const form = new FormData();
+  form.append("name", "Runcam Nano 4");
+  form.append("quantity", "1");
+  form.append("status", "unused");
+  await handler(new Request("http://localhost/parts", { method: "POST", body: form }));
+  const res = await handler(new Request("http://localhost/"));
+  assertEquals(res.status, 200);
+  const html = await res.text();
+  assertStringIncludes(html, "Runcam Nano 4");
 });
 
 Deno.test("POST /parts with missing name returns 400", async () => {
@@ -45,6 +58,16 @@ Deno.test("POST /parts with missing name returns 400", async () => {
   form.append("quantity", "1");
   const res = await handler(new Request("http://localhost/parts", { method: "POST", body: form }));
   assertEquals(res.status, 400);
+});
+
+Deno.test("POST /parts with invalid parent_id treats part as top-level", async () => {
+  const { handler } = makeApp();
+  const form = new FormData();
+  form.append("name", "Quad Beta");
+  form.append("parent_id", "not-a-number");
+  const res = await handler(new Request("http://localhost/parts", { method: "POST", body: form }));
+  assertEquals(res.status, 303);
+  assertEquals(res.headers.get("Location"), "/");
 });
 
 Deno.test("POST /parts supports optional parent_id", async () => {
@@ -58,7 +81,7 @@ Deno.test("POST /parts supports optional parent_id", async () => {
   const res = await handler(new Request("http://localhost/parts", { method: "POST", body: form }));
   assertEquals(res.status, 303);
   // Redirect to the parent's detail page
-  assertStringIncludes(res.headers.get("Location") ?? "", `/parts/${quadId}`);
+  assertEquals(res.headers.get("Location"), `/parts/${quadId}`);
 });
 
 // ─── Part detail ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Addresses issue #13: 'quick add on the homepage doesn't do anything'.

- Fix weak `assertStringIncludes(location, "/")` assertions to use `assertEquals` with exact expected URLs, so tests would catch regressions in redirect behavior
- Add integration test: POST /parts then GET / verifies the new part actually appears on the homepage (end-to-end quick-add coverage)
- Add test: invalid (non-numeric) parent_id is sanitized to null, creating the part as top-level rather than crashing
- Fix silent crash: parseInt("not-a-number") → NaN was passed to SQLite; now sanitized to null via isNaN() guard
- Wrap createPart/updatePart/movePart DB calls in try/catch to return a 500 instead of crashing the server on unexpected DB errors

https://claude.ai/code/session_01SbZUeWebHkvFBFeZsDRcsa