### PR TITLE
fix: graceful SIGTERM handling, request logging, fix Dockerfile vendo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@ FROM denoland/deno:2.2.1
 
 WORKDIR /app
 
-# Copy source files
+# Copy source files and vendored dependencies
 COPY deno.json .
 COPY main.ts .
 COPY db.ts .
-
-# Pre-cache dependencies
-RUN deno cache main.ts
+COPY vendor/ vendor/
 
 # Create data directories
 RUN mkdir -p /data/photos

--- a/main.ts
+++ b/main.ts
@@ -515,13 +515,44 @@ export function makeHandler(db: DB) {
   };
 }
 
+function withLogging(handler: (req: Request) => Promise<Response>): (req: Request) => Promise<Response> {
+  return async (req: Request) => {
+    const start = Date.now();
+    const { method } = req;
+    const path = new URL(req.url).pathname;
+    try {
+      const res = await handler(req);
+      console.log(`${method} ${path} → ${res.status} (${Date.now() - start}ms)`);
+      return res;
+    } catch (err) {
+      console.error(`${method} ${path} → ERROR`, err);
+      return new Response("Internal Server Error", { status: 500 });
+    }
+  };
+}
+
 // When run directly (not imported), start the server
 if (import.meta.main) {
   const db = initDb(DB_PATH);
-  const handler = makeHandler(db);
   const port = parseInt(Deno.env.get("PORT") ?? "8000", 10);
-  console.log(`FPV Inventory running on http://localhost:${port}`);
-  Deno.serve({ port }, handler);
-}
 
-export default makeHandler(initDb(DB_PATH));
+  const server = Deno.serve(
+    {
+      port,
+      onListen: ({ port, hostname }) => {
+        console.log(`FPV Inventory running on http://${hostname}:${port}`);
+      },
+    },
+    withLogging(makeHandler(db)),
+  );
+
+  const shutdown = async () => {
+    console.log("Shutting down gracefully...");
+    await server.shutdown();
+    db.close();
+    console.log("Shutdown complete.");
+  };
+
+  Deno.addSignalListener("SIGTERM", shutdown);
+  Deno.addSignalListener("SIGINT", shutdown);
+}


### PR DESCRIPTION
…r copy

Fixes #20. Three issues addressed:

1. Exit code 143 (SIGTERM): The server had no signal handler, so any SIGTERM from Docker/runtipi would kill the process immediately. Now registers SIGTERM/SIGINT handlers to drain in-flight requests via server.shutdown() before closing the DB.

2. No visibility into what was happening: Added a logging wrapper so every request logs method, path, status code, and duration. Errors are logged with full details.

3. Removed the module-level `export default makeHandler(initDb(DB_PATH))` which opened a second unused DB connection on every startup.

Also updates the Dockerfile to COPY vendor/ instead of running `deno cache` (network-free build, consistent with vendor:true in deno.json).

https://claude.ai/code/session_01ErEvQPgCfrT5B3YyY1HhY1