### PR TITLE
docs: add collaboration/PR workflow guidance to claude.md

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -3,6 +3,16 @@
 This repository is a template for building using Claude Code. This guide establishes development best practices.
 
 
+## Collaboration
+
+We collaborate through GitHub issues and pull requests. Make sure the `gh` tool is installed and use it with the token in your `env`.
+
+```bash
+apt install gh -y
+```
+
+**Always use a branch + PR workflow** — never push or commit directly to `main`. Use `gh pr create` to open a PR for review. Do not use the local git proxy; use `gh` with the token in env for all GitHub operations.
+
 ## Development Philosophy and Methodology
 
 ### Red-Green-Refactor (TDD)


### PR DESCRIPTION
## Summary

- Adds a Collaboration section mirroring the rtappstore CLAUDE.md
- Specifies use of `gh` with the env token for all GitHub operations
- Makes explicit that all changes must go through a branch + PR, never direct to `main`

## Test plan

- [ ] Review the updated claude.md wording